### PR TITLE
Implement global scoring system

### DIFF
--- a/include/object/Bullet.hpp
+++ b/include/object/Bullet.hpp
@@ -9,6 +9,8 @@ public:
     void update();
     void draw(SDL_Renderer *renderer);
     bool isOffScreen() const;
+    void setDead();
+    bool isDead() const;
     float getX() const { return x; }
     float getY() const { return y; }
     float getRadius() const { return radius; }
@@ -17,4 +19,5 @@ private:
     float x, y;
     float speed = 8.0f;
     int radius = 3;
+    bool dead = false;
 };

--- a/include/object/Enemy.hpp
+++ b/include/object/Enemy.hpp
@@ -15,6 +15,10 @@ public:
     bool checkCollision(float bulletX, float bulletY, float radius);
 
     bool isDead() const { return dead; }
+    void onHit();
+    float getX() const { return x; }
+    float getY() const { return y; }
+    float getRadius() const { return size; }
 
     std::vector<EnemyBullet> bullets;
     int fireCooldown = 60;

--- a/include/object/Player.hpp
+++ b/include/object/Player.hpp
@@ -27,6 +27,8 @@ public:
     bool isInvincible() const { return invincible; }
     int getLives() const { return lives; }
 
+    void removeDeadBullets();
+
 private:
     float x,
         y;

--- a/include/scene/GameScene.hpp
+++ b/include/scene/GameScene.hpp
@@ -22,8 +22,6 @@ public:
     float playerX() const { return player.getX(); }
     float playerY() const { return player.getY(); }
     std::vector<EnemyBullet> enemyBullets;
-    bool playerDead = false;
-    int score = 0;
 
 private:
     Player player;

--- a/include/system/ScoreManager.hpp
+++ b/include/system/ScoreManager.hpp
@@ -1,0 +1,14 @@
+#pragma once
+
+class ScoreManager {
+public:
+    static ScoreManager &getInstance();
+
+    void reset();
+    void addScore(int value);
+    int getScore() const;
+
+private:
+    ScoreManager() = default;
+    int score = 0;
+};

--- a/src/object/Bullet.cpp
+++ b/src/object/Bullet.cpp
@@ -18,3 +18,13 @@ bool Bullet::isOffScreen() const
 {
     return y + radius < 0;
 }
+
+void Bullet::setDead()
+{
+    dead = true;
+}
+
+bool Bullet::isDead() const
+{
+    return dead;
+}

--- a/src/object/Enemy.cpp
+++ b/src/object/Enemy.cpp
@@ -62,6 +62,11 @@ bool Enemy::checkCollision(float bulletX, float bulletY, float radius)
     return false;
 }
 
+void Enemy::onHit()
+{
+    dead = true;
+}
+
 std::optional<EnemyBullet> Enemy::tryFire(float playerX, float playerY)
 {
     if (fireCooldown <= 0)

--- a/src/object/Player.cpp
+++ b/src/object/Player.cpp
@@ -103,3 +103,10 @@ void Player::draw(SDL_Renderer *renderer)
         b.draw(renderer);
     }
 }
+
+void Player::removeDeadBullets()
+{
+    bullets.erase(std::remove_if(bullets.begin(), bullets.end(),
+                                 [](const Bullet &b) { return b.isDead(); }),
+                  bullets.end());
+}

--- a/src/scene/GameScene.cpp
+++ b/src/scene/GameScene.cpp
@@ -1,5 +1,6 @@
 #include "scene/GameScene.hpp"
 #include <SDL2/SDL.h>
+#include "system/ScoreManager.hpp"
 
 void drawText(SDL_Renderer *renderer, TTF_Font *font, const std::string &text, int x, int y)
 {
@@ -24,6 +25,8 @@ GameScene::GameScene()
     {
         SDL_Log("Failed to load font: %s", TTF_GetError());
     }
+
+    ScoreManager::getInstance().reset();
 }
 
 void GameScene::update()
@@ -88,7 +91,7 @@ void GameScene::update()
                 bullet.setDead(); // 弾を無効化
                 if (enemy.isDead())
                 {
-                    score += 1000; // スコア加算
+                    ScoreManager::getInstance().addScore(1000);
                 }
             }
         }
@@ -132,11 +135,15 @@ void GameScene::draw(SDL_Renderer *renderer)
         SDL_SetRenderDrawColor(renderer, 0, 0, 0, 200);
         SDL_Rect overlay = {0, 0, 640, 480};
         SDL_RenderFillRect(renderer, &overlay);
-        // 本当はフォントで Game Over 表示したい！（後で実装）
+        drawText(renderer, font, "GAME OVER", 260, 220);
+        drawText(renderer, font,
+                 "FINAL SCORE: " + std::to_string(ScoreManager::getInstance().getScore()),
+                 200, 260);
     }
 
     drawText(renderer, font, "LIVES: " + std::to_string(player.getLives()), 10, 10);
-    drawText(renderer, font, "SCORE: " + std::to_string(score), 10, 30);
+    drawText(renderer, font,
+             "SCORE: " + std::to_string(ScoreManager::getInstance().getScore()), 10, 30);
 
     // あとで "SCORE: 000000", "POWER: ★★" なども追加可能
 }

--- a/src/system/ScoreManager.cpp
+++ b/src/system/ScoreManager.cpp
@@ -1,0 +1,22 @@
+#include "system/ScoreManager.hpp"
+
+ScoreManager &ScoreManager::getInstance()
+{
+    static ScoreManager instance;
+    return instance;
+}
+
+void ScoreManager::reset()
+{
+    score = 0;
+}
+
+void ScoreManager::addScore(int value)
+{
+    score += value;
+}
+
+int ScoreManager::getScore() const
+{
+    return score;
+}


### PR DESCRIPTION
## Summary
- add a `ScoreManager` singleton to handle game score
- extend `Bullet` and `Enemy` with lifecycle helpers
- allow `Player` to purge dead bullets
- display score via `ScoreManager` in `GameScene` and show final result on death

## Testing
- `./Project_Build.sh` *(fails: sdl2 not found)*

------
https://chatgpt.com/codex/tasks/task_e_685d360d9ebc83238ec95a8681d9d89d